### PR TITLE
Add credentials. Artifact versions. Parameterize build. Code clean up.

### DIFF
--- a/hosts
+++ b/hosts
@@ -14,9 +14,12 @@ maven_artifact_id=exampleArtifact
 maven_pom=pom.xml
 maven_build_goals=clean package
 maven_test_goals="clean org.jacoco:jacoco-maven-plugin:prepare-agent test integration-test sonar:sonar -Dsonar.host.url={{ sonar_url }}"
-build_child_projects="{{ job_prefix }}-Deploy-Dev, {{ job_prefix }}-Test-EAP"
+build_child_projects="{{ job_prefix }}-Test-EAP"
+build_child_project_with_params="{{ job_prefix }}-Deploy-Dev"
 downstream_projects="{{ job_prefix }}-Deploy-Stg"
 nexus_repo=http://nexus.example.com/content/repositories/releases/
+nexus_user=deployment
+nexus_password=deployment123
 openshift_user=""
 openshift_password=""
 openshift_server=master.example.com

--- a/roles/java-eap/defaults/main.yml
+++ b/roles/java-eap/defaults/main.yml
@@ -8,9 +8,12 @@ maven_artifact_id: ""
 maven_pom: pom.xml
 maven_build_goals: clean package
 maven_test_goals: "clean org.jacoco:jacoco-maven-plugin:prepare-agent test integration-test sonar:sonar -Dsonar.host.url={{ sonar_url }}"
-build_child_projects: "{{ job_prefix }}-Deploy-Dev, {{ job_prefix }}-Test-EAP"
+build_child_project: "{{ {{ job_prefix }}-Test-EAP"
+build_child_project_with_params: "{{ job_prefix }}-Deploy-Dev"
 downstream_projects: "{{ job_prefix }}-Deploy-Stg"
 nexus_repo: http://nexus.example.com/content/repositories/releases/
+nexus_user: ""
+nexus_password: ""
 openshift_user: ""
 openshift_password: ""
 openshift_server: server.ose.example.com

--- a/roles/java-eap/defaults/main.yml
+++ b/roles/java-eap/defaults/main.yml
@@ -2,6 +2,7 @@ job_prefix: ""
 git_url: https://git.example.com/project/project.git
 git_branch: ""
 git_context: ""
+scm_credentials_id: ""
 sonar_url: http://sonar.example.com
 maven_group_id: ""
 maven_artifact_id: ""
@@ -14,6 +15,7 @@ downstream_projects: "{{ job_prefix }}-Deploy-Stg"
 nexus_repo: http://nexus.example.com/content/repositories/releases/
 nexus_user: ""
 nexus_password: ""
+alternate_repo_url: ""
 openshift_user: ""
 openshift_password: ""
 openshift_server: server.ose.example.com

--- a/roles/java-eap/tasks/jenkins-credentials.yml
+++ b/roles/java-eap/tasks/jenkins-credentials.yml
@@ -1,6 +1,4 @@
 ---
-    - debug: msg="System {{ pipeline_user }} has uuid {{  pipeline_password }}"
-
     - name: Adding Credentials
       uri:
         url: "{{ jenkins_host_url }}/scriptText"

--- a/roles/java-eap/tasks/jenkins-credentials.yml
+++ b/roles/java-eap/tasks/jenkins-credentials.yml
@@ -1,0 +1,26 @@
+---
+    - debug: msg="System {{ pipeline_user }} has uuid {{  pipeline_password }}"
+
+    - name: Adding Credentials
+      uri:
+        url: "{{ jenkins_host_url }}/scriptText"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
+        method: POST
+        return_content: yes
+        HEADER_Content-Type: "application/x-www-form-urlencoded"
+        body: "script={{ lookup('template', 'credentials.groovy.j2') }}"
+      tags: creds
+
+    - name: Adding Maven Settings
+      uri:
+        url: "{{ jenkins_host_url }}/scriptText"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
+        method: POST
+        return_content: yes
+        HEADER_Content-Type: "application/x-www-form-urlencoded"
+        body: "script={{ lookup('template', 'addSettingsFile.groovy.j2') }}"
+      tags: creds

--- a/roles/java-eap/tasks/jenkins-pipeline.yml
+++ b/roles/java-eap/tasks/jenkins-pipeline.yml
@@ -1,34 +1,12 @@
 ---
 
-    - name: Create output directory
-      #file: path=/etc/some_directory state=directory mode=0755
-      file: path=output state=directory mode=0755
-
-    - name: Create Build Config File
-      template: src=java-build.j2 dest=output/java-build.xml
-
-    - name: Create Test Config File
-      template: src=java-test-eap.j2 dest=output/java-test-eap.xml
-
-    - name: Create Dev Deploy Config File
-      template: src=java-deploy-dev.j2 dest=output/java-deploy-dev.xml
-
-    - name: Create Stg  Deploy Config File
-      template: src=java-deploy-stg.j2 dest=output/java-deploy-stg.xml
-
-    - name: Create List View 
-      template: src=java-list-view.j2 dest=output/java-list-view.xml
-
-    - name: Create Pipeline View
-      template: src=java-pipeline-view.j2 dest=output/java-pipeline-view.xml
-
     - name: Deploy {{ job_prefix }}-Build
       uri: 
         url: "{{ jenkins_host_url }}/createItem?name={{ job_prefix }}-Build"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
-        body: "{{ lookup('file', 'output/java-build.xml') }}"
+        body: "{{ lookup('template', 'java-build.j2') }}"
 
     - name: Deploy {{ job_prefix }}-Test-EAP
       uri: 
@@ -36,7 +14,7 @@
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
-        body: "{{ lookup('file', 'output/java-test-eap.xml') }}"
+        body: "{{ lookup('template', 'java-test-eap.j2') }}"
 
     - name: Deploy {{ job_prefix }}-Deploy-Dev
       uri: 
@@ -44,7 +22,7 @@
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
-        body: "{{ lookup('file', 'output/java-deploy-dev.xml') }}"
+        body: "{{ lookup('template', 'java-deploy-dev.j2') }}"
 
     - name: Deploy {{ job_prefix }}-Deploy-Stg
       uri: 
@@ -52,7 +30,7 @@
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
-        body: "{{ lookup('file', 'output/java-deploy-stg.xml') }}"
+        body: "{{ lookup('template', 'java-deploy-stg.j2') }}"
 
     - name: Deploy {{ jenkins_listview_name }}
       uri: 
@@ -60,7 +38,7 @@
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
-        body: "{{ lookup('file', 'output/java-list-view.xml') }}"
+        body: "{{ lookup('template', 'java-list-view.j2') }}"
 
     - name: Deploy {{ jenkins_pipeline_name }}
       uri: 
@@ -68,8 +46,14 @@
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
-        body: "{{ lookup('file', 'output/java-pipeline-view.xml') }}"
+        body: "{{ lookup('template', 'java-pipeline-view.j2') }}"
 
-    - name: Remove Output Directory
-      file: path=output state=absent
+    - name: Adding Credentials
+      uri:
+        url: "{{ jenkins_host_url }}/scriptText"
+        method: POST
+        return_content: yes
+        HEADER_Content-Type: "application/x-www-form-urlencoded"
+        body: "{{ lookup('template', 'credentials.groovy.j2') }}"
+      tags: creds
 

--- a/roles/java-eap/tasks/jenkins-pipeline.yml
+++ b/roles/java-eap/tasks/jenkins-pipeline.yml
@@ -1,59 +1,73 @@
 ---
-
     - name: Deploy {{ job_prefix }}-Build
       uri: 
         url: "{{ jenkins_host_url }}/createItem?name={{ job_prefix }}-Build"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
         body: "{{ lookup('template', 'java-build.j2') }}"
+      tags: jenkins-jobs
 
     - name: Deploy {{ job_prefix }}-Test-EAP
       uri: 
         url: "{{ jenkins_host_url }}/createItem?name={{ job_prefix }}-Test-EAP"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
         body: "{{ lookup('template', 'java-test-eap.j2') }}"
+      tags: jenkins-jobs
 
     - name: Deploy {{ job_prefix }}-Deploy-Dev
       uri: 
         url: "{{ jenkins_host_url }}/createItem?name={{ job_prefix }}-Deploy-Dev"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
         body: "{{ lookup('template', 'java-deploy-dev.j2') }}"
+      tags: jenkins-jobs
 
     - name: Deploy {{ job_prefix }}-Deploy-Stg
       uri: 
         url: "{{ jenkins_host_url }}/createItem?name={{ job_prefix }}-Deploy-Stg"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
         body: "{{ lookup('template', 'java-deploy-stg.j2') }}"
+      tags: jenkins-jobs
 
     - name: Deploy {{ jenkins_listview_name }}
       uri: 
         url: "{{ jenkins_host_url }}/createView?name={{ jenkins_listview_name }}"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
         body: "{{ lookup('template', 'java-list-view.j2') }}"
+      tags: jenkins-views
 
     - name: Deploy {{ jenkins_pipeline_name }}
       uri: 
         url: "{{ jenkins_host_url }}/createView?name={{ jenkins_pipeline_name }}"
+        force_basic_auth: yes
+        user: "{{ pipeline_user }}"
+        password: "{{ pipeline_password }}"
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/xml"
         body: "{{ lookup('template', 'java-pipeline-view.j2') }}"
-
-    - name: Adding Credentials
-      uri:
-        url: "{{ jenkins_host_url }}/scriptText"
-        method: POST
-        return_content: yes
-        HEADER_Content-Type: "application/x-www-form-urlencoded"
-        body: "script={{ lookup('template', 'credentials.groovy.j2') }}"
-      tags: creds
+      tags: jenkins-views
 

--- a/roles/java-eap/tasks/jenkins-pipeline.yml
+++ b/roles/java-eap/tasks/jenkins-pipeline.yml
@@ -54,6 +54,6 @@
         method: POST
         return_content: yes
         HEADER_Content-Type: "application/x-www-form-urlencoded"
-        body: "{{ lookup('template', 'credentials.groovy.j2') }}"
+        body: "script={{ lookup('template', 'credentials.groovy.j2') }}"
       tags: creds
 

--- a/roles/java-eap/tasks/main.yml
+++ b/roles/java-eap/tasks/main.yml
@@ -1,2 +1,4 @@
 ---
+  - include: jenkins-credentials.yml  
+  
   - include: jenkins-pipeline.yml  

--- a/roles/java-eap/templates/addSettingsFile.groovy.j2
+++ b/roles/java-eap/templates/addSettingsFile.groovy.j2
@@ -17,7 +17,7 @@ uuid = randomUUID() as String
 println uuid
 
 String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n\
-          <settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"\
+<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"\
           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\
           xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd\">\
 \n\
@@ -34,7 +34,7 @@ String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n\
    <mirror>\n\
       <id>nexus</id>\n\
       <mirrorOf>*</mirrorOf>\n\
-      <url>{{ nexus_repo }} </url>\n\
+      <url>{{ nexus_mirror }} </url>\n\
     </mirror>\n\
   </mirrors>\n\
 \n\

--- a/roles/java-eap/templates/addSettingsFile.groovy.j2
+++ b/roles/java-eap/templates/addSettingsFile.groovy.j2
@@ -1,0 +1,61 @@
+import java.util.Collections;
+
+import static java.util.UUID.randomUUID
+import jenkins.model.*
+import org.jenkinsci.lib.configprovider.model.Config
+import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig
+import org.jenkinsci.plugins.configfiles.maven.security.ServerCredentialMapping;
+import com.cloudbees.plugins.credentials.*
+import com.cloudbees.plugins.credentials.common.*
+import com.cloudbees.plugins.credentials.domains.*
+import com.cloudbees.plugins.credentials.impl.*
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import hudson.util.Secret;
+
+uuid = randomUUID() as String
+
+println uuid
+
+String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n\
+          <settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"\
+          xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\
+          xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd\">\
+\n\
+  <pluginGroups>\n\
+  </pluginGroups>\n\
+            \n\
+  <proxies>\n\
+  </proxies>\n\
+\n\
+  <servers>\n\
+  </servers>\n\
+\n\
+  <mirrors>\n\
+   <mirror>\n\
+      <id>nexus</id>\n\
+      <mirrorOf>*</mirrorOf>\n\
+      <url>{{ nexus_repo }} </url>\n\
+    </mirror>\n\
+  </mirrors>\n\
+\n\
+  <profiles>\n\
+  </profiles>\n\
+\n\
+\n\
+</settings>" 
+
+ServerCredentialMapping useNexusCredentials = new ServerCredentialMapping("nexus", "nexusId")
+java.util.List<ServerCredentialMapping> credentialMappingList = new java.util.ArrayList<ServerCredentialMapping>()
+credentialMappingList.add(useNexusCredentials)
+
+GlobalMavenSettingsConfig config = new GlobalMavenSettingsConfig("{{ mvnSettingsId }}", "Custom MVN settings", "global settings", content, GlobalMavenSettingsConfig.isReplaceAllDefault, credentialMappingList);
+
+domain = Domain.global()
+org.jenkinsci.lib.configprovider.ConfigProvider provider = Jenkins.instance.getExtensionList('org.jenkinsci.lib.configprovider.ConfigProvider')[0];
+println provider;
+
+
+println Jenkins.instance.getExtensionList('org.jenkinsci.lib.configprovider.ConfigProvider')
+
+
+provider.save(config)

--- a/roles/java-eap/templates/credentials.groovy.j2
+++ b/roles/java-eap/templates/credentials.groovy.j2
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.*
 import com.cloudbees.plugins.credentials.common.*
 import com.cloudbees.plugins.credentials.domains.*
 import com.cloudbees.plugins.credentials.impl.*
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import hudson.util.Secret;
 
@@ -14,11 +15,14 @@ println uuid
 domain = Domain.global()
 store = Jenkins.instance.getExtensionList('com.cloudbees.plugins.credentials.SystemCredentialsProvider')[0].getStore()
 
-StringCredentialsImpl c = new StringCredentialsImpl(CredentialsScope.GLOBAL, uuid, "Sample Credential Description", Secret.fromString("s3cr3t"));
-store.addCredentials(domain, c)
+//StringCredentialsImpl c = new StringCredentialsImpl(CredentialsScope.GLOBAL, uuid, "Sample Credential Description", Secret.fromString("s3cr3t"));
+//store.addCredentials(domain, c)
 
 UsernamePasswordCredentialsImpl user = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "openshiftId", "OpenShift Access", "{{ openshift_user }}", "{{ openshift_password }}")
 store.addCredentials(domain, user);
 
 user = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "nexusId", "Nexus Access", "{{ nexus_user}}", "{{ nexus_password }}")
 store.addCredentials(domain, user);
+
+BasicSSHUserPrivateKey sshKey = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "pipelineSSH", "{{ pipeline_user }}", new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource("{{ jenkins_ssh_key_location }}"), null, "Pipeline SSH") 
+store.addCredentials(domain, sshKey);

--- a/roles/java-eap/templates/credentials.groovy.j2
+++ b/roles/java-eap/templates/credentials.groovy.j2
@@ -24,5 +24,5 @@ store.addCredentials(domain, user);
 user = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "nexusId", "Nexus Access", "{{ nexus_user}}", "{{ nexus_password }}")
 store.addCredentials(domain, user);
 
-BasicSSHUserPrivateKey sshKey = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "pipelineSSH", "{{ pipeline_user }}", new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource("{{ jenkins_ssh_key_location }}"), null, "Pipeline SSH") 
+BasicSSHUserPrivateKey sshKey = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, "gitSSH", "{{ git_user }}", new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource("{{ jenkins_ssh_key_location }}"), null, "Pipeline SSH") 
 store.addCredentials(domain, sshKey);

--- a/roles/java-eap/templates/credentials.groovy.j2
+++ b/roles/java-eap/templates/credentials.groovy.j2
@@ -1,0 +1,24 @@
+script=import static java.util.UUID.randomUUID
+import jenkins.model.*
+import com.cloudbees.plugins.credentials.*
+import com.cloudbees.plugins.credentials.common.*
+import com.cloudbees.plugins.credentials.domains.*
+import com.cloudbees.plugins.credentials.impl.*
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import hudson.util.Secret;
+
+uuid = randomUUID() as String
+
+println uuid
+
+domain = Domain.global()
+store = Jenkins.instance.getExtensionList('com.cloudbees.plugins.credentials.SystemCredentialsProvider')[0].getStore()
+
+StringCredentialsImpl c = new StringCredentialsImpl(CredentialsScope.GLOBAL, uuid, "Sample Credential Description", Secret.fromString("s3cr3t"));
+store.addCredentials(domain, c)
+
+UsernamePasswordCredentialsImpl user = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "openshiftId", "OpenShift Access", "{{ openshift_user }}", "{{ openshift_password }}")
+store.addCredentials(domain, user);
+
+user = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "nexusId", "Nexus Access", "{{ nexus_user}}", "{{ nexus_password }}")
+store.addCredentials(domain, user);

--- a/roles/java-eap/templates/credentials.groovy.j2
+++ b/roles/java-eap/templates/credentials.groovy.j2
@@ -1,4 +1,4 @@
-script=import static java.util.UUID.randomUUID
+import static java.util.UUID.randomUUID
 import jenkins.model.*
 import com.cloudbees.plugins.credentials.*
 import com.cloudbees.plugins.credentials.common.*

--- a/roles/java-eap/templates/java-build.j2
+++ b/roles/java-eap/templates/java-build.j2
@@ -23,11 +23,10 @@
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
     <gitTool>KM Git</gitTool><!-- //TODO kmcanoy-->
-    <browser class="hudson.plugins.git.browser.AssemblaWeb">
-      <url></url>
-    </browser>
     <submoduleCfg class="list"/>
-    <extensions/>
+    <extensions>
+      <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
+    </extensions>
   </scm>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
@@ -63,7 +62,7 @@
   <reporters/>
   <publishers>
     <hudson.tasks.BuildTrigger>
-      <childProjects>{{ build_child_projects }}</childProjects>
+      <childProjects>{{ build_child_project }}</childProjects>
       <threshold>
         <name>SUCCESS</name>
         <ordinal>0</ordinal>
@@ -81,9 +80,31 @@
       <configs/>
       <downstreamProjectNames>{{ downstream_projects }}</downstreamProjectNames>
     </au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger>
+    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.30">
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>BUILD_JOB_NUMBER=$BUILD_NUMBER</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>{{ build_child_project_with_params }}</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.BuildTrigger>
   </publishers>
   <buildWrappers/>
-  <prebuilders/>
+  <prebuilders>
+    <hudson.tasks.Maven>
+      <targets>build-helper:parse-version versions:set -DnewVersion=${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-$BUILD_NUMBER -f {{ maven_pom }}</targets>
+      <mavenName>M3</mavenName><!-- TODO KMCANOY -->
+      <usePrivateRepository>false</usePrivateRepository>
+      <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+      <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+    </hudson.tasks.Maven>
+  </prebuilders>
   <postbuilders/>
   <runPostStepsIfResult>
     <name>SUCCESS</name>

--- a/roles/java-eap/templates/java-build.j2
+++ b/roles/java-eap/templates/java-build.j2
@@ -17,7 +17,6 @@
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
-    <gitTool>KM Git</gitTool><!-- //TODO kmcanoy-->
     <submoduleCfg class="list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
@@ -29,7 +28,7 @@
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
     <hudson.triggers.SCMTrigger>
-      <spec>* * * * *</spec>
+      <spec>{{ git_polling }}</spec>
       <ignorePostCommitHooks>false</ignorePostCommitHooks>
     </hudson.triggers.SCMTrigger>
   </triggers>
@@ -58,25 +57,12 @@
   </globalSettings>
   <reporters/>
   <publishers>
-    <hudson.tasks.BuildTrigger>
-      <childProjects>{{ build_child_project }}</childProjects>
-      <threshold>
-        <name>SUCCESS</name>
-        <ordinal>0</ordinal>
-        <color>BLUE</color>
-        <completeBuild>true</completeBuild>
-      </threshold>
-    </hudson.tasks.BuildTrigger>
     <hudson.maven.RedeployPublisher>
       <id>nexus</id>
       <url>{{ nexus_repo }}</url>
       <uniqueVersion>true</uniqueVersion>
       <evenIfUnstable>false</evenIfUnstable>
     </hudson.maven.RedeployPublisher>
-    <au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger plugin="build-pipeline-plugin@1.5.2">
-      <configs/>
-      <downstreamProjectNames>{{ downstream_projects }}</downstreamProjectNames>
-    </au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger>
     <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.30">
       <configs>
         <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
@@ -99,7 +85,9 @@
       <mavenName>(Default)</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
-      <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+      <globalSettings class="org.jenkinsci.plugins.configfiles.maven.job.MvnGlobalSettingsProvider" plugin="config-file-provider@2.11">
+        <settingsConfigId>{{ mvnSettingsId }}</settingsConfigId>
+      </globalSettings>
     </hudson.tasks.Maven>
   </prebuilders>
   <postbuilders/>

--- a/roles/java-eap/templates/java-build.j2
+++ b/roles/java-eap/templates/java-build.j2
@@ -3,17 +3,12 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.18.2">
-      <projectUrl>{{ git_url }}</projectUrl>
-      <displayName></displayName>
-    </com.coravy.hudson.plugins.github.GithubProjectProperty>
-  </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.4">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
         <url>{{ git_url }}</url>
+        <credentialsId>{{ scm_credentials_id }}</credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -58,7 +53,9 @@
   <disableTriggerDownstreamProjects>false</disableTriggerDownstreamProjects>
   <blockTriggerWhenBuilding>true</blockTriggerWhenBuilding>
   <settings class="jenkins.mvn.DefaultSettingsProvider"/>
-  <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+  <globalSettings class="org.jenkinsci.plugins.configfiles.maven.job.MvnGlobalSettingsProvider" plugin="config-file-provider@2.11">
+    <settingsConfigId>{{ mvnSettingsId }}</settingsConfigId>
+  </globalSettings>
   <reporters/>
   <publishers>
     <hudson.tasks.BuildTrigger>
@@ -71,7 +68,7 @@
       </threshold>
     </hudson.tasks.BuildTrigger>
     <hudson.maven.RedeployPublisher>
-      <id>Releases</id>
+      <id>nexus</id>
       <url>{{ nexus_repo }}</url>
       <uniqueVersion>true</uniqueVersion>
       <evenIfUnstable>false</evenIfUnstable>
@@ -99,7 +96,7 @@
   <prebuilders>
     <hudson.tasks.Maven>
       <targets>build-helper:parse-version versions:set -DnewVersion=${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-$BUILD_NUMBER -f {{ maven_pom }}</targets>
-      <mavenName>M3</mavenName><!-- TODO KMCANOY -->
+      <mavenName>(Default)</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/roles/java-eap/templates/java-deploy-dev.j2
+++ b/roles/java-eap/templates/java-deploy-dev.j2
@@ -57,7 +57,7 @@ if [ -z &quot;$BUILD_CONFIG&quot; -o &quot;$BUILD_CONFIG&quot; == &quot;NAME&quo
   echo &quot;Create a new app&quot;
   oc new-app --template=eap64-basic-s2i -p \
   APPLICATION_NAME=$APP_NAME,HOSTNAME_HTTP=$APP_HOSTNAME,SOURCE_REPOSITORY_URL=$APP_GIT,SOURCE_REPOSITORY_REF=$APP_GIT_REF,CONTEXT_DIR=$APP_GIT_CONTEXT_DIR\
-   -l name=$APP_NAME
+   --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER,REPO_URL=$ALTERNATE_REPO_URL -l name=$APP_NAME
  
   echo &quot;Find build id&quot;
   BUILD_ID=`oc get builds | tail -1 | awk &apos;{print $1}&apos;`
@@ -116,7 +116,7 @@ while [ $rc -ne 0 -a $count -lt $attempts ]; do
 done
 
 # stream the logs for the build that just started
-oc build-logs $BUILD_ID
+oc logs $BUILD_ID-build
 
 sleep 5
 
@@ -209,10 +209,15 @@ fi
     </hudson.tasks.Shell>
   </builders>
   <publishers>
-    <au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger plugin="build-pipeline-plugin@1.5.2">
-      <configs/>
-      <downstreamProjectNames>{{ job_prefix }}-Deploy-Stg</downstreamProjectNames>
-    </au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger>
+    <hudson.tasks.BuildTrigger>
+      <childProjects>TM-Test-EAP</childProjects>
+      <threshold>
+        <name>SUCCESS</name>
+        <ordinal>0</ordinal>
+        <color>BLUE</color>
+        <completeBuild>true</completeBuild>
+      </threshold>
+    </hudson.tasks.BuildTrigger>
   </publishers>
   <buildWrappers>
     <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.8">

--- a/roles/java-eap/templates/java-deploy-dev.j2
+++ b/roles/java-eap/templates/java-deploy-dev.j2
@@ -11,6 +11,11 @@
           <description>Takes the value of the Maven Java Build job in the pipeline and uses it to retrieve the artifact created</description>
           <defaultValue>0</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ALTERNATE_REPO_URL</name>
+          <description>A URL that differs from the distribution management in the pom.xml</description>
+          <defaultValue>{{ alternate_repo }}</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -24,8 +29,20 @@
   <builders>
     <hudson.tasks.Shell>
       <command>echo &quot;MVN BUILD JOB NUMBER = $BUILD_JOB_NUMBER&quot;
+echo &quot;ALT REPO = $ALTERNATE_REPO_URL&quot;
 
+APP_HOSTNAME={{ dev_application_host_url }}
+APP_NAME={{ maven_artifact_id }}
+APP_GIT={{ git_url }}
+APP_GIT_REF={{ git_branch }}
+APP_GIT_CONTEXT_DIR={{ git_context }}
+OSE_SERVER={{ openshift_server }}
+CERT_PATH=
+DEVEL_PROJ_NAME={{ openshift_dev_project }}
+
+set +x
 oc login -u$USER_NAME -p$USER_PASSWD --server=$OSE_SERVER --certificate-authority=$CERT_PATH
+set -x
 
 oc project $DEVEL_PROJ_NAME
 
@@ -67,7 +84,7 @@ else
 
   # Application already exists, just need to start a new build
   echo &quot;App Exists. Triggering application build and deployment&quot;
-  BUILD_ID=`oc start-build ${BUILD_CONFIG} --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER`
+  BUILD_ID=`oc start-build ${BUILD_CONFIG} --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER,REPO_URL=$ALTERNATE_REPO_URL`
   
 fi
 
@@ -198,19 +215,6 @@ fi
     </au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger>
   </publishers>
   <buildWrappers>
-    <EnvInjectBuildWrapper plugin="envinject@1.92.1">
-      <info>
-        <propertiesContent>APP_HOSTNAME={{ dev_application_host_url }}
-APP_NAME={{ maven_artifact_id }}
-APP_GIT={{ git_url }}
-APP_GIT_REF={{ git_branch }}
-APP_GIT_CONTEXT_DIR={{ git_context }}
-OSE_SERVER={{ openshift_server }}
-CERT_PATH=
-DEVEL_PROJ_NAME={{ openshift_dev_project }}</propertiesContent>
-        <loadFilesFromMaster>false</loadFilesFromMaster>
-      </info>
-    </EnvInjectBuildWrapper>
     <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.8">
       <bindings>
         <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>

--- a/roles/java-eap/templates/java-deploy-dev.j2
+++ b/roles/java-eap/templates/java-deploy-dev.j2
@@ -3,7 +3,17 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties/>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>BUILD_JOB_NUMBER</name>
+          <description>Takes the value of the Maven Java Build job in the pipeline and uses it to retrieve the artifact created</description>
+          <defaultValue>0</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
@@ -13,7 +23,9 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>oc login -u$USER_NAME -p$USER_PASSWD --server=$OSE_SERVER --certificate-authority=$CERT_PATH
+      <command>echo &quot;MVN BUILD JOB NUMBER = $BUILD_JOB_NUMBER&quot;
+
+oc login -u$USER_NAME -p$USER_PASSWD --server=$OSE_SERVER --certificate-authority=$CERT_PATH
 
 oc project $DEVEL_PROJ_NAME
 
@@ -55,7 +67,7 @@ else
 
   # Application already exists, just need to start a new build
   echo &quot;App Exists. Triggering application build and deployment&quot;
-  BUILD_ID=`oc start-build ${BUILD_CONFIG}`
+  BUILD_ID=`oc start-build ${BUILD_CONFIG} --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER`
   
 fi
 
@@ -193,26 +205,20 @@ APP_NAME={{ maven_artifact_id }}
 APP_GIT={{ git_url }}
 APP_GIT_REF={{ git_branch }}
 APP_GIT_CONTEXT_DIR={{ git_context }}
-USER_NAME={{ openshift_user }}
 OSE_SERVER={{ openshift_server }}
 CERT_PATH=
 DEVEL_PROJ_NAME={{ openshift_dev_project }}</propertiesContent>
         <loadFilesFromMaster>false</loadFilesFromMaster>
       </info>
     </EnvInjectBuildWrapper>
-    <EnvInjectPasswordWrapper plugin="envinject@1.92.1">
-      <injectGlobalPasswords>false</injectGlobalPasswords>
-      <maskPasswordParameters>true</maskPasswordParameters>
-      <passwordEntries>
-        <EnvInjectPasswordEntry>
-          <name>USER_PASSWD</name>
-          <value>{{ openshift_password }}</value>
-        </EnvInjectPasswordEntry>
-        <EnvInjectPasswordEntry>
-          <name></name>
-          <value>q2tnc7RcipUXaUupteozoA==</value>
-        </EnvInjectPasswordEntry>
-      </passwordEntries>
-    </EnvInjectPasswordWrapper>
+    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.8">
+      <bindings>
+        <org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+          <credentialsId>openshiftId</credentialsId>
+          <usernameVariable>USER_NAME</usernameVariable>
+          <passwordVariable>USER_PASSWD</passwordVariable>
+        </org.jenkinsci.plugins.credentialsbinding.impl.UsernamePasswordMultiBinding>
+      </bindings>
+    </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
   </buildWrappers>
 </project>

--- a/roles/java-eap/templates/java-deploy-dev.j2
+++ b/roles/java-eap/templates/java-deploy-dev.j2
@@ -57,36 +57,18 @@ if [ -z &quot;$BUILD_CONFIG&quot; -o &quot;$BUILD_CONFIG&quot; == &quot;NAME&quo
   echo &quot;Create a new app&quot;
   oc new-app --template=eap64-basic-s2i -p \
   APPLICATION_NAME=$APP_NAME,HOSTNAME_HTTP=$APP_HOSTNAME,SOURCE_REPOSITORY_URL=$APP_GIT,SOURCE_REPOSITORY_REF=$APP_GIT_REF,CONTEXT_DIR=$APP_GIT_CONTEXT_DIR\
-   --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER,REPO_URL=$ALTERNATE_REPO_URL -l name=$APP_NAME
+    -l name=$APP_NAME
+
+  CANCEL_BUILD_RESULT=`oc cancel-build $APP_NAME-1`
+  echo &quot;Cancel Result: $CANCEL_BUILD_RESULT&quot;
  
-  echo &quot;Find build id&quot;
-  BUILD_ID=`oc get builds | tail -1 | awk &apos;{print $1}&apos;`
-  rc=1
-  attempts=75
-  count=0
-  while [ $rc -ne 0 -a $count -lt $attempts ]; do
-    BUILD_ID=`oc get builds | tail -1 | awk &apos;{print $1}&apos;`
-    if [ $BUILD_ID == &quot;NAME&quot; ]; then
-      count=$(($count+1))
-      echo &quot;Attempt $count/$attempts&quot;
-      sleep 5
-    else 
-      rc=0
-      echo &quot;Build Id is :&quot; ${BUILD_ID}
-    fi 
-  done
-
-  if [ $rc -ne 0 ]; then
-    echo &quot;Fail: Build could not be found after maximum attempts&quot;
-    exit 1
-  fi 
-else
-
-  # Application already exists, just need to start a new build
-  echo &quot;App Exists. Triggering application build and deployment&quot;
-  BUILD_ID=`oc start-build ${BUILD_CONFIG} --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER,REPO_URL=$ALTERNATE_REPO_URL`
-  
+  BUILD_CONFIG=$APP_NAME
 fi
+ 
+# Start a new build
+echo &quot;Triggering application build and deployment&quot;
+BUILD_ID=`oc start-build ${BUILD_CONFIG} --env=BUILD_JOB_NUMBER=$BUILD_JOB_NUMBER,REPO_URL=$ALTERNATE_REPO_URL`
+  
 
 echo &quot;Waiting for build to start&quot;
 rc=1
@@ -125,7 +107,7 @@ rc=1
 count=0
 attempts=100
 while [ $rc -ne 0 -a $count -lt $attempts ]; do
-  status=`oc get build ${BUILD_ID} -t &apos;{{'{{'}}.status.phase}}&apos;`
+  status=`oc get build ${BUILD_ID} --template &apos;{{'{{'}}.status.phase}}&apos;`
   if [[ $status == &quot;Failed&quot; || $status == &quot;Error&quot; || $status == &quot;Canceled&quot; ]]; then
     echo &quot;Fail: Build completed with unsuccessful status: ${status}&quot;
     exit 1

--- a/roles/java-eap/templates/java-deploy-stg.j2
+++ b/roles/java-eap/templates/java-deploy-stg.j2
@@ -13,7 +13,11 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>oc project $DEVEL_PROJ_NAME
+      <command>DEVEL_PROJ_NAME={{ openshift_dev_project }}
+PROD_PROJ_NAME={{ openshift_stg_project }}
+APP_HOSTNAME={{ application_host_url }}
+
+oc project $DEVEL_PROJ_NAME
 
 IS_NAME=`oc get is| tail -1|awk &apos;{print $1}&apos;`
 
@@ -66,14 +70,5 @@ fi</command>
   </builders>
   <publishers/>
   <buildWrappers>
-    <EnvInjectBuildWrapper plugin="envinject@1.92.1">
-      <info>
-        <propertiesContent>DEVEL_PROJ_NAME={{ openshift_dev_project }} 
-PROD_PROJ_NAME={{ openshift_stg_project }}
-APP_HOSTNAME={{ application_host_url }}
-        </propertiesContent>
-        <loadFilesFromMaster>false</loadFilesFromMaster>
-      </info>
-    </EnvInjectBuildWrapper>
   </buildWrappers>
 </project>

--- a/roles/java-eap/templates/java-test-eap.j2
+++ b/roles/java-eap/templates/java-test-eap.j2
@@ -48,7 +48,13 @@
   <settings class="jenkins.mvn.DefaultSettingsProvider"/>
   <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
   <reporters/>
-  <publishers/>
+  <publishers>
+    <au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger plugin="build-pipeline-plugin@1.4.9">
+      <configs/>
+      <downstreamProjectNames>{{ test_child_project }}</downstreamProjectNames>
+    </au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger>
+  </publishers>
+  <buildWrappers/>
   <prebuilders>
     <EnvInjectBuilder plugin="envinject@1.92.1">
       <info>

--- a/roles/java-eap/templates/java-test-eap.j2
+++ b/roles/java-eap/templates/java-test-eap.j2
@@ -49,15 +49,12 @@
   <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
   <reporters/>
   <publishers/>
-  <buildWrappers>
-    <EnvInjectBuildWrapper plugin="envinject@1.92.1">
+  <prebuilders>
+    <EnvInjectBuilder plugin="envinject@1.92.1">
       <info>
         <propertiesContent>JBOSS_HOME=$WORKSPACE/jboss/jboss-eap-6.4</propertiesContent>
-        <loadFilesFromMaster>false</loadFilesFromMaster>
       </info>
-    </EnvInjectBuildWrapper>
-  </buildWrappers>
-  <prebuilders>
+    </EnvInjectBuilder>
     <hudson.tasks.Shell>
       <command>echo &quot;JBOSS_HOME&quot; $JBOSS_HOME
 


### PR DESCRIPTION
This request address a few different things. In retrospect I probably should have a split out the commits. 

1. Automate Credentials - This provides the ability with Ansible to add credentials through the credentials plugin into Jenkins. These credentials are not for logging into Jenkins. They are for build jobs that need credentials for other system. In this first case, the ability to add OpenShift credentials and Nexus credentials are added. The OpenShift credentials have been incorporated into the deploy job. Previously, the less secure EnvInject plugin was used.

2. Versioning of the artifact produced. Relies on maven. This strategy appends the build number to the archive. Based on this the downstream jobs will use this build number as a parameter in that build (automated) to pick up the archive for deployment into a container.

3. Cleans up the use of templates in the task. Instead of creating temporary xml it now merges the template in the uri module.